### PR TITLE
Fallback to render discussions as viewed by guests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changed
 
 - Increase PHPStan level from 5 to 7 and add some return types along the way.
+- Fallback to rendering discussion links as viewed by guests if request
+  is null.
 
 ## [v1.0.2] - 2023-02-14
 

--- a/src/Formatter/CrossReferencesRenderer.php
+++ b/src/Formatter/CrossReferencesRenderer.php
@@ -27,6 +27,7 @@ use Flarum\Discussion\Discussion;
 use Flarum\Foundation\ErrorHandling\LogReporter;
 use Flarum\Http\RequestUtil;
 use Flarum\Locale\Translator;
+use Flarum\User\Guest;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 use s9e\TextFormatter\Renderer;
@@ -60,9 +61,9 @@ class CrossReferencesRenderer
      */
     public function __invoke(Renderer $renderer, $context, ?string $xml, ?ServerRequestInterface $request)
     {
-        $actor = null;
+        $actor = new Guest();
         if (is_null($request)) {
-            $msg = 'request is "null", falling back to display discussions as unknown. This is probably due to another extension not passing this parameter to "Formatter->render()". See stack trace below.';
+            $msg = 'request is "null", falling back to display discussions as viewed by guests. This is probably due to another extension not passing this parameter to "Formatter->render()". See stack trace below.';
             $this->log->report(new RuntimeException($msg));
         } else {
             $actor = RequestUtil::getActor($request);
@@ -70,7 +71,7 @@ class CrossReferencesRenderer
         $filterCrossReferences = function ($attributes) use ($actor) {
             /** @var Discussion|null */
             $discussion = Discussion::find($attributes['id']);
-            if ($discussion && $actor && $actor->can('viewForum', $discussion)) {
+            if ($discussion && $actor->can('viewForum', $discussion)) {
                 $attributes['title'] = $discussion->title;
             } else {
                 $attributes['title'] = $this->translator->trans('club-1-cross-references.forum.unknown_discussion');


### PR DESCRIPTION
If $request is null, we check the permissions of the Guest user instead of always rendering the discussions as "unknown". This allows to at least render correctly fully public discussions.
