### PR TITLE
Improve detecting permissions to view referenced discussions

### DIFF
--- a/js/src/forum/index.ts
+++ b/js/src/forum/index.ts
@@ -53,10 +53,11 @@ function addSourceLinkReplacement() {
       if (match == null) {
         return;
       }
-      if (a.text !== a.href && !a.text.startsWith(a.href + ' ')) {
+      if (a.text !== a.href && !a.text.startsWith(a.href + ' ') && !a.classList.contains('redirection-initialised')) {
+        a.classList.add('redirection-initialised');
         a.addEventListener('click', (e) => {
-          m.route.set(this.getAttribute('href'))
           e.preventDefault();
+          m.route.set(this.getAttribute('href'))
         });
       }
     });

--- a/js/src/forum/index.ts
+++ b/js/src/forum/index.ts
@@ -28,7 +28,6 @@ import DiscussionHero from 'flarum/forum/components/DiscussionHero';
 import DiscussionListItem from 'flarum/forum/components/DiscussionListItem';
 import { ResponseCache } from './cache';
 import DiscussionId from './components/DiscussionId';
-import DiscussionLink from './components/DiscussionLink';
 import DiscussionReferencedPost from './components/DiscussionReferencedPost';
 
 app.initializers.add('club-1-cross-references', function(app) {
@@ -54,12 +53,7 @@ function addSourceLinkReplacement() {
       if (match == null) {
         return;
       }
-      if (a.text === a.href) {
-        const discussionId = match[1];
-        const span = document.createElement('span');
-        m.mount(span, {view: () => m(DiscussionLink, {discussionId, href: a.href})});
-        a.replaceWith(span)
-      } else {
+      if (a.text !== a.href && !a.text.startsWith(a.href + ' ')) {
         a.addEventListener('click', (e) => {
           m.route.set(this.getAttribute('href'))
           e.preventDefault();

--- a/src/Formatter/CrossReferencesRenderer.php
+++ b/src/Formatter/CrossReferencesRenderer.php
@@ -24,9 +24,11 @@
 namespace Club1\CrossReferences\Formatter;
 
 use Flarum\Discussion\Discussion;
+use Flarum\Foundation\Config;
 use Flarum\Foundation\ErrorHandling\LogReporter;
 use Flarum\Http\RequestUtil;
 use Flarum\Locale\Translator;
+use Flarum\User\Guest;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 use s9e\TextFormatter\Renderer;
@@ -44,10 +46,16 @@ class CrossReferencesRenderer
      */
     protected $log;
 
-    public function __construct(Translator $translator, LogReporter $log)
+    /**
+     * @var Config
+     */
+    protected $config;
+
+    public function __construct(Translator $translator, LogReporter $log, Config $config)
     {
         $this->translator = $translator;
         $this->log = $log;
+        $this->config = $config;
     }
 
     /**
@@ -60,20 +68,22 @@ class CrossReferencesRenderer
      */
     public function __invoke(Renderer $renderer, $context, ?string $xml, ?ServerRequestInterface $request)
     {
-        $actor = null;
         if (is_null($request)) {
-            $msg = 'request is "null", falling back to display discussions as unknown. This is probably due to another extension not passing this parameter to "Formatter->render()". See stack trace below.';
-            $this->log->report(new RuntimeException($msg));
+            if ($this->config->inDebugMode()) {
+                $msg = 'request is "null", falling back to display discussion as for Guest. This is probably due to another extension not passing this parameter to "Formatter->render()". See stack trace below.';
+                $this->log->report(new RuntimeException($msg));
+            }
+            $actor = new Guest();
         } else {
             $actor = RequestUtil::getActor($request);
         }
         $filterCrossReferences = function ($attributes) use ($actor) {
             /** @var Discussion|null */
-            $discussion = Discussion::find($attributes['id']);
-            if ($discussion && $actor && $actor->can('viewForum', $discussion)) {
+            $discussion = Discussion::whereVisibleTo($actor)->firstWhere('id', $attributes['id']);
+            if ($discussion) {
                 $attributes['title'] = $discussion->title;
             } else {
-                $attributes['title'] = $this->translator->trans('club-1-cross-references.forum.unknown_discussion');
+                $attributes['title'] = $attributes['url'];
                 $attributes['unknown'] = true;
             }
             $attributes['comment'] = $this->translator->trans('club-1-cross-references.forum.comment');

--- a/tests/unit/CrossReferencesRendererTest.php
+++ b/tests/unit/CrossReferencesRendererTest.php
@@ -24,6 +24,7 @@
 namespace Club1\CrossReferences\Tests\unit;
 
 use Club1\CrossReferences\Formatter\CrossReferencesRenderer;
+use Flarum\Foundation\Config;
 use Flarum\Foundation\ErrorHandling\LogReporter;
 use Flarum\Locale\Translator;
 use Flarum\Testing\unit\TestCase;
@@ -50,6 +51,8 @@ class CrossReferencesRendererTest extends TestCase
     protected $log;
     /** @var \Flarum\Discussion\Discussion&MockInterface */
     protected $discussionModel;
+    /** @var Config&MockInterface */
+    protected $config;
 
     public function setUp(): void
     {
@@ -60,6 +63,7 @@ class CrossReferencesRendererTest extends TestCase
         $this->translator = m::mock(Translator::class);
         $this->renderer = m::mock(Renderer::class);
         $this->log = m::mock(LogReporter::class);
+        $this->config = m::mock(Config::class);
 
         // Mock Eloquent Discussion Model by creating an alias in the autoloader.
         // This only works if the aliased class is not yet loaded.
@@ -77,7 +81,7 @@ class CrossReferencesRendererTest extends TestCase
         $this->translator->shouldReceive('trans')->with('club-1-cross-references.forum.comment')->once()->andReturn('comment');
         $xml = "<$tag id=\"$id\"></$tag>";
 
-        $renderer = new CrossReferencesRenderer($this->translator, $this->log);
+        $renderer = new CrossReferencesRenderer($this->translator, $this->log, $this->config);
         $rendered = $renderer($this->renderer, null, $xml, $this->request);
         assertEquals(['unknown'], Utils::getAttributeValues($rendered, $tag, 'title'));
         assertEquals([true], Utils::getAttributeValues($rendered, $tag, 'unknown'));
@@ -97,7 +101,7 @@ class CrossReferencesRendererTest extends TestCase
         $this->actor->shouldReceive('can')->with('viewForum', $discussion)->once()->andReturn(false);
         $xml = "<$tag id=\"$id\"></$tag>";
 
-        $renderer = new CrossReferencesRenderer($this->translator, $this->log);
+        $renderer = new CrossReferencesRenderer($this->translator, $this->log, $this->config);
         $rendered = $renderer($this->renderer, null, $xml, $this->request);
         assertEquals(['unknown'], Utils::getAttributeValues($rendered, $tag, 'title'));
         assertEquals([true], Utils::getAttributeValues($rendered, $tag, 'unknown'));
@@ -117,7 +121,7 @@ class CrossReferencesRendererTest extends TestCase
         $this->log->shouldReceive('report')->once();
         $xml = "<$tag id=\"$id\"></$tag>";
 
-        $renderer = new CrossReferencesRenderer($this->translator, $this->log);
+        $renderer = new CrossReferencesRenderer($this->translator, $this->log, $this->config);
         $rendered = $renderer($this->renderer, null, $xml, null);
         assertEquals(['unknown'], Utils::getAttributeValues($rendered, $tag, 'title'));
         assertEquals([true], Utils::getAttributeValues($rendered, $tag, 'unknown'));
@@ -136,7 +140,7 @@ class CrossReferencesRendererTest extends TestCase
         $this->actor->shouldReceive('can')->with('viewForum', $discussion)->once()->andReturn(true);
         $xml = "<$tag id=\"$id\"></$tag>";
 
-        $renderer = new CrossReferencesRenderer($this->translator, $this->log);
+        $renderer = new CrossReferencesRenderer($this->translator, $this->log, $this->config);
         $rendered = $renderer($this->renderer, null, $xml, $this->request);
         assertEquals([$title], Utils::getAttributeValues($rendered, $tag, 'title'));
         assertEquals([], Utils::getAttributeValues($rendered, $tag, 'unknown'));


### PR DESCRIPTION
Replaces #30

This PR fixes detecting permissions for discussions visibility, as `$actor->can('viewForum', $discussion)` sytnax is probably [incorrect](https://discord.com/channels/360670804914208769/360689688815730701/1076217045475143720) and did not worked for me.

It also improves behavior in case of lack of permissions or errors caused by other extensions:
1. Fallbacks user to Guest in case if request or actor was not passed to formatter - it should fix all issues for public forums.
2. Instead displaying "unknown discussion" placeholder, it leaves URL intact, so it is still clickable.
3. logs errors only when debug mode is enabled.